### PR TITLE
Evita el cache de Vercel en /bio al borrar o editar productos.

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -149,6 +149,23 @@ const nextConfig = {
   async headers() {
     return [
       {
+        source: '/bio',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'no-store, no-cache, must-revalidate, max-age=0, s-maxage=0',
+          },
+          {
+            key: 'CDN-Cache-Control',
+            value: 'no-store',
+          },
+          {
+            key: 'Vercel-CDN-Cache-Control',
+            value: 'no-store',
+          },
+        ],
+      },
+      {
         source: '/(.*)', // Aplica a todas las rutas
         headers: [
           {

--- a/src/app/api/link-in-bio/config/route.js
+++ b/src/app/api/link-in-bio/config/route.js
@@ -2,6 +2,11 @@ import { NextResponse } from 'next/server';
 import connectDB from '../../../../config/connectDB';
 import Users from '../../../../models/userModel';
 import LinkInBioConfig from '../../../../models/linkInBioConfigModel';
+import { revalidateLinkInBio } from '../../../../lib/revalidateLinkInBio';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
 
 const CONFIG_KEY = 'default';
 
@@ -30,7 +35,12 @@ export async function GET() {
       {
         mentoria: doc.mentoria || {},
       },
-      { status: 200 }
+      {
+        status: 200,
+        headers: {
+          'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+        },
+      }
     );
   } catch (error) {
     console.error('GET /api/link-in-bio/config:', error);
@@ -74,12 +84,19 @@ export async function PUT(req) {
       { new: true, upsert: true, setDefaultsOnInsert: true }
     ).lean();
 
+    revalidateLinkInBio();
+
     return NextResponse.json(
       {
         message: 'Configuración de bio actualizada',
         mentoria: doc?.mentoria || {},
       },
-      { status: 200 }
+      {
+        status: 200,
+        headers: {
+          'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+        },
+      }
     );
   } catch (error) {
     console.error('PUT /api/link-in-bio/config:', error);

--- a/src/app/api/product/createProduct/route.js
+++ b/src/app/api/product/createProduct/route.js
@@ -13,6 +13,7 @@ import { getApiErrorMessage, getApiErrorStatus } from '../../../../utils/apiErro
 import { normalizeCursoLandingConfig } from '../../../../types/cursoLanding';
 import { resolveInvitacionGrupoWhatsappFromPayload } from '../../../../lib/resolveInvitacionGrupoWhatsapp';
 import { buildCursoStripeSuccessUrl } from '../../../../lib/cursoPaymentUrls';
+import { revalidateLinkInBio } from '../../../../lib/revalidateLinkInBio';
 
 connectDB();
 
@@ -483,6 +484,8 @@ export async function POST(req) {
       } catch (cacheError) {
       }
     }
+
+    revalidateLinkInBio();
 
     return NextResponse.json(
       { message: 'Producto creado con éxito', product },

--- a/src/app/api/product/delete/[workShopId]/route.js
+++ b/src/app/api/product/delete/[workShopId]/route.js
@@ -3,8 +3,14 @@ import Bills from '../../../../../models/billModel';
 import User from '../../../../../models/userModel';
 import Exam from '../../../../../models/examModel';
 import Product from '../../../../../models/productModel';
+import connectDB from '../../../../../config/connectDB';
+import { revalidateLinkInBio } from '../../../../../lib/revalidateLinkInBio';
 
 import { ObjectId } from 'mongodb';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
 
 export async function DELETE(req) {
     try {
@@ -12,10 +18,13 @@ export async function DELETE(req) {
         productId
         } = await req.json();
     if (req.method === 'DELETE') {
+      await connectDB();
 
       const product = await Product.deleteOne({
         _id: ObjectId(productId)
       });
+
+      revalidateLinkInBio();
 
       return NextResponse.json({ message: `Product deleted`, success: true }, { status: 200 })
     }

--- a/src/app/api/product/updateProduct/route.js
+++ b/src/app/api/product/updateProduct/route.js
@@ -7,6 +7,7 @@ import { resolveInvitacionGrupoWhatsappFromPayload } from '../../../../lib/resol
 import { normalizeCursoLandingConfig } from '../../../../types/cursoLanding';
 import { ensureCursoPreventaPaymentLinks } from '../../../../lib/ensureCursoPreventaPaymentLinks';
 import { ensureCursoLanzamientoPaymentLinks } from '../../../../lib/ensureCursoLanzamientoPaymentLinks';
+import { revalidateLinkInBio } from '../../../../lib/revalidateLinkInBio';
 
 connectDB();
 
@@ -427,6 +428,8 @@ export async function PUT(req) {
         updatedProduct.markModified('cursoConfig');
         await updatedProduct.save();
       }
+
+      revalidateLinkInBio();
 
       return NextResponse.json(
         { message: 'Producto actualizado con éxito', product: updatedProduct },

--- a/src/app/bio/page.tsx
+++ b/src/app/bio/page.tsx
@@ -7,6 +7,11 @@ import LinkInBioConfig from '../../models/linkInBioConfigModel';
 import { buildMentoriaLinkInBioCard } from '../../lib/linkInBioMentoria';
 import { mapProductsForLinkInBio } from '../../lib/linkInBioProducts';
 
+/** Evita Full Route Cache de Vercel: la bio lee Mongo en cada request. */
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
+
 export const metadata: Metadata = {
   title: 'Mateo Molfino | Bio',
   description:

--- a/src/lib/revalidateLinkInBio.ts
+++ b/src/lib/revalidateLinkInBio.ts
@@ -1,0 +1,12 @@
+import { revalidatePath } from 'next/cache';
+
+/** Invalida el HTML cacheado de /bio (y aliases) en Vercel/Next. */
+export function revalidateLinkInBio() {
+  try {
+    revalidatePath('/bio');
+    revalidatePath('/links');
+    revalidatePath('/link-in-bio');
+  } catch (error) {
+    console.error('[revalidateLinkInBio]', error);
+  }
+}


### PR DESCRIPTION
Fuerza render dinámico de la bio y revalida la ruta al crear, actualizar o eliminar productos y al cambiar la config de mentoría.