### PR TITLE
Permite otorgar Cuerpo Autónomo a varios emails en un solo request

### DIFF
--- a/.github/workflows/branch-to-develop-pr.yml
+++ b/.github/workflows/branch-to-develop-pr.yml
@@ -1,0 +1,39 @@
+name: PR branch -> develop
+
+on:
+  push:
+    branches-ignore:
+      - develop
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-pr:
+    if: github.event.deleted == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Crear PR hacia develop si no existe uno abierto
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+
+          EXISTING_PR=$(gh pr list --base develop --head "$BRANCH" --state open --json number --jq '.[0].number')
+
+          if [ -n "$EXISTING_PR" ]; then
+            echo "Ya existe el PR #$EXISTING_PR de $BRANCH -> develop. No se crea uno nuevo."
+            exit 0
+          fi
+
+          gh pr create \
+            --base develop \
+            --head "$BRANCH" \
+            --title "$BRANCH -> develop" \
+            --body "PR automático generado al pushear a \`$BRANCH\`. Revisar y mergear cuando esté listo." \
+            || echo "No se pudo crear el PR (probablemente no hay diferencias entre $BRANCH y develop). El workflow no falla por esto."

--- a/src/app/api/dev/grant-cuerpo-autonomo/route.ts
+++ b/src/app/api/dev/grant-cuerpo-autonomo/route.ts
@@ -5,11 +5,43 @@ import { resolveCuerpoAutonomoProductId } from '../../../../lib/userHasCuerpoAut
 
 /**
  * SOLO LOCAL — bloqueado en producción a propósito (ver guard abajo).
- * Da acceso gratuito al curso Cuerpo Autónomo a un usuario ya existente,
- * igual que a alguien que lo pagó (misma forma de entrada en
+ * Da acceso gratuito al curso Cuerpo Autónomo a uno o varios usuarios ya
+ * existentes, igual que a alguien que lo pagó (misma forma de entrada en
  * cursosAdquiridos que arma fulfillCoursePurchase, pero sin transacción real
  * ni mail de bienvenida — mismo criterio que grantAnnualMentorshipProductGifts).
+ *
+ * Body acepta { email: string } o { emails: string[] }. Un email que no
+ * corresponde a ningún usuario no aborta el resto del lote: se reporta en
+ * `notFound` y la respuesta sigue siendo 200.
  */
+async function grantToEmail(email: string, productId: string) {
+  const user = await Users.findOne({ email });
+  if (!user) {
+    return { email, found: false as const };
+  }
+
+  const alreadyHasAccess = (user.cursosAdquiridos || []).some(
+    (entry: any) => entry?.productoId?.toString() === productId
+  );
+  if (alreadyHasAccess) {
+    return { email, found: true as const, alreadyHadAccess: true, userId: user._id.toString() };
+  }
+
+  user.cursosAdquiridos = user.cursosAdquiridos || [];
+  user.cursosAdquiridos.push({
+    productoId: productId,
+    fechaCompra: new Date(),
+    metodoPago: 'gratis',
+    transaccionId: `dev-grant-cuerpo-autonomo:${Date.now()}`,
+    monto: 0,
+    moneda: 'USD',
+    bienvenidaPendiente: false,
+  });
+  await user.save();
+
+  return { email, found: true as const, alreadyHadAccess: false, userId: user._id.toString() };
+}
+
 export async function POST(req: Request) {
   if (process.env.NODE_ENV === 'production' || process.env.VERCEL_ENV === 'production') {
     return NextResponse.json({ error: 'No disponible en producción' }, { status: 403 });
@@ -17,9 +49,17 @@ export async function POST(req: Request) {
 
   try {
     const body = await req.json().catch(() => null);
-    const email = String(body?.email || '').trim().toLowerCase();
-    if (!email) {
-      return NextResponse.json({ error: 'Falta email' }, { status: 400 });
+    const rawEmails = Array.isArray(body?.emails) ? body.emails : [body?.email];
+    const emails = Array.from(
+      new Set(
+        rawEmails
+          .map((e: unknown) => String(e || '').trim().toLowerCase())
+          .filter((e: string) => e.length > 0)
+      )
+    ) as string[];
+
+    if (emails.length === 0) {
+      return NextResponse.json({ error: 'Falta email o emails' }, { status: 400 });
     }
 
     await connectDB();
@@ -32,34 +72,24 @@ export async function POST(req: Request) {
       );
     }
 
-    const user = await Users.findOne({ email });
-    if (!user) {
-      return NextResponse.json(
-        { error: `No existe un usuario con el email "${email}"` },
-        { status: 404 }
-      );
-    }
+    const results = await Promise.all(emails.map((email) => grantToEmail(email, productId)));
 
-    const alreadyHasAccess = (user.cursosAdquiridos || []).some(
-      (entry: any) => entry?.productoId?.toString() === productId
-    );
-    if (alreadyHasAccess) {
-      return NextResponse.json({ ok: true, alreadyHadAccess: true, userId: user._id.toString() });
-    }
+    const granted = results.filter((r) => r.found && !r.alreadyHadAccess);
+    const alreadyHadAccess = results.filter((r) => r.found && r.alreadyHadAccess);
+    const notFound = results.filter((r) => !r.found).map((r) => r.email);
 
-    user.cursosAdquiridos = user.cursosAdquiridos || [];
-    user.cursosAdquiridos.push({
-      productoId: productId,
-      fechaCompra: new Date(),
-      metodoPago: 'gratis',
-      transaccionId: `dev-grant-cuerpo-autonomo:${Date.now()}`,
-      monto: 0,
-      moneda: 'USD',
-      bienvenidaPendiente: false,
+    return NextResponse.json({
+      ok: true,
+      summary: {
+        requested: emails.length,
+        granted: granted.length,
+        alreadyHadAccess: alreadyHadAccess.length,
+        notFound: notFound.length,
+      },
+      granted: granted.map((r) => ({ email: r.email, userId: r.userId })),
+      alreadyHadAccessList: alreadyHadAccess.map((r) => ({ email: r.email, userId: r.userId })),
+      notFound,
     });
-    await user.save();
-
-    return NextResponse.json({ ok: true, alreadyHadAccess: false, userId: user._id.toString() });
   } catch (error: any) {
     console.error('[dev/grant-cuerpo-autonomo]', error);
     return NextResponse.json({ error: error?.message || 'Error interno' }, { status: 500 });


### PR DESCRIPTION
El endpoint dev/grant-cuerpo-autonomo acepta ahora { emails: string[] } además de { email }. Procesa el lote en paralelo y nunca falla por un email inexistente: siempre responde 200 con un resumen (granted, alreadyHadAccess, notFound).